### PR TITLE
Charset reader options

### DIFF
--- a/atom.go
+++ b/atom.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-func parseAtom(data []byte) (*Feed, error) {
+func parseAtom(data []byte, options ParseOptions) (*Feed, error) {
 	warnings := false
 	feed := atomFeed{}
 	p := xml.NewDecoder(bytes.NewReader(data))

--- a/atom.go
+++ b/atom.go
@@ -13,6 +13,9 @@ func parseAtom(data []byte, options ParseOptions) (*Feed, error) {
 	p := xml.NewDecoder(bytes.NewReader(data))
 	p.Strict = false
 	p.CharsetReader = CharsetReader
+	if options.CharsetReader != nil {
+		p.CharsetReader = options.CharsetReader
+	}
 	err := p.Decode(&feed)
 	if err != nil {
 		return nil, err

--- a/atom_test.go
+++ b/atom_test.go
@@ -43,7 +43,7 @@ func TestParseContentWithoutCDATA(t *testing.T) {
   </feed>
   `
 
-	feed, err := parseAtom([]byte(doc))
+	feed, err := parseAtom([]byte(doc), ParseOptions{})
 	if err != nil {
 		t.Error("Should not error")
 	}
@@ -94,7 +94,7 @@ func TestParseContentWithCDATA(t *testing.T) {
   </feed>
   `
 
-	feed, err := parseAtom([]byte(doc))
+	feed, err := parseAtom([]byte(doc), ParseOptions{})
 	if err != nil {
 		t.Error("Should not error")
 	}
@@ -142,7 +142,7 @@ func TestParseContentWithoutContent(t *testing.T) {
   </feed>
   `
 
-	feed, err := parseAtom([]byte(doc))
+	feed, err := parseAtom([]byte(doc), ParseOptions{})
 	if err != nil {
 		t.Error("Should not error")
 	}

--- a/charset_reader_test.go
+++ b/charset_reader_test.go
@@ -33,7 +33,9 @@ func TestParseUTF16LE(t *testing.T) {
 
 	for _, testCase := range testCases {
 		input, headers := parseTestCase(testCase.File)
-		feed, err := Parse(input, headers, "")
+		feed, err := Parse(input, ParseOptions{
+			ResponseHeaders: headers,
+		})
 		if err != nil {
 			t.Error("Should not error on parsing", err)
 			continue

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/erkie/rss
 go 1.13
 
 require (
-	github.com/axgle/mahonia v0.0.0-20180208002826-3358181d7394
-	golang.org/x/text v0.3.2
+	golang.org/x/net v0.0.0-20220822230855-b0a4917ee28c
+	golang.org/x/text v0.3.7
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,8 @@
-github.com/axgle/mahonia v0.0.0-20180208002826-3358181d7394 h1:OYA+5W64v3OgClL+IrOD63t4i/RW7RqrAVl9LTZ9UqQ=
-github.com/axgle/mahonia v0.0.0-20180208002826-3358181d7394/go.mod h1:Q8n74mJTIgjX4RBBcHnJ05h//6/k6foqmgE45jTQtxg=
-golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
-golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/net v0.0.0-20220822230855-b0a4917ee28c h1:JVAXQ10yGGVbSyoer5VILysz6YKjdNT2bsvlayjqhes=
+golang.org/x/net v0.0.0-20220822230855-b0a4917ee28c/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -24,7 +24,7 @@ func TestParseCategory(t *testing.T) {
 			t.Fatalf("Reading %s: %v", test, err)
 		}
 
-		feed, err := Parse(data, nil, "")
+		feed, err := Parse(data, ParseOptions{})
 		if err != nil {
 			t.Fatalf("Parsing %s: %v", test, err)
 		}

--- a/rss.go
+++ b/rss.go
@@ -12,6 +12,7 @@ import (
 )
 
 type ParseOptions struct {
+	CharsetReader   func(charset string, input io.Reader) (io.Reader, error)
 	ResponseHeaders http.Header
 	FinalURL        string
 }

--- a/rss.go
+++ b/rss.go
@@ -23,7 +23,7 @@ func Parse(data []byte, responseHeaders http.Header, finalURL string) (*Feed, er
 
 	possibleParsers := make([]ParserFunc, 0)
 
-	if strings.Contains(string(data), "\"http://purl.org/rss/1.0/\"") {
+	if strings.Contains(string(data), "\"http://purl.org/rss/1.0/\"") || strings.Contains(string(data), "<rdf:RDF") {
 		if debug {
 			fmt.Println("[i] Parsing as RSS 1.0")
 		}

--- a/rss_1.0.go
+++ b/rss_1.0.go
@@ -14,6 +14,9 @@ func parseRSS1(data []byte, options ParseOptions) (*Feed, error) {
 	p := xml.NewDecoder(bytes.NewReader(data))
 	p.Strict = false
 	p.CharsetReader = CharsetReader
+	if options.CharsetReader != nil {
+		p.CharsetReader = options.CharsetReader
+	}
 	err := p.Decode(&feed)
 	if err != nil {
 		return nil, err

--- a/rss_1.0.go
+++ b/rss_1.0.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-func parseRSS1(data []byte) (*Feed, error) {
+func parseRSS1(data []byte, options ParseOptions) (*Feed, error) {
 	warnings := false
 	feed := rss1_0Feed{}
 	p := xml.NewDecoder(bytes.NewReader(data))

--- a/rss_1.0_test.go
+++ b/rss_1.0_test.go
@@ -18,7 +18,7 @@ func TestParseRDFRSS10(t *testing.T) {
 		t.Fatalf("Reading test file %v", err)
 	}
 
-	feed, err := Parse(data, nil, "")
+	feed, err := Parse(data, ParseOptions{})
 	if err != nil {
 		t.Error("Should not error on parsing", err)
 	}

--- a/rss_2.0.go
+++ b/rss_2.0.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-func parseRSS2(data []byte) (*Feed, error) {
+func parseRSS2(data []byte, options ParseOptions) (*Feed, error) {
 	warnings := false
 	feed := rss2_0Feed{}
 	p := xml.NewDecoder(bytes.NewReader(data))

--- a/rss_2.0.go
+++ b/rss_2.0.go
@@ -13,6 +13,9 @@ func parseRSS2(data []byte, options ParseOptions) (*Feed, error) {
 	p := xml.NewDecoder(bytes.NewReader(data))
 	p.Strict = false
 	p.CharsetReader = CharsetReader
+	if options.CharsetReader != nil {
+		p.CharsetReader = options.CharsetReader
+	}
 	err := p.Decode(&feed)
 	if err != nil {
 		return nil, err

--- a/rss_test.go
+++ b/rss_test.go
@@ -23,7 +23,7 @@ func TestParseTitle(t *testing.T) {
 			t.Fatalf("Reading %s: %v", test, err)
 		}
 
-		feed, err := Parse(data, nil, "")
+		feed, err := Parse(data, ParseOptions{})
 		if err != nil {
 			t.Fatalf("Parsing %s: %v", test, err)
 		}
@@ -48,7 +48,7 @@ func TestEnclosure(t *testing.T) {
 			t.Fatalf("Reading %s: %v", test, err)
 		}
 
-		feed, err := Parse(data, nil, "")
+		feed, err := Parse(data, ParseOptions{})
 		if err != nil {
 			t.Fatalf("Parsing %s: %v", test, err)
 		}
@@ -82,7 +82,7 @@ func TestEnclosureLink(t *testing.T) {
 			t.Fatalf("Reading %s: %v", test, err)
 		}
 
-		feed, err := Parse(data, nil, "")
+		feed, err := Parse(data, ParseOptions{})
 		if err != nil {
 			t.Fatalf("Parsing %s: %v", test, err)
 		}


### PR DESCRIPTION
- Remove depedence on mahonia and use golang.org/x/net/html/charset instead
- Make it possible to customize the CharsetReader by passing in a CharsetReader in the ParseOptions
- Refactor how options are passed in to rss.Parse. Use rss.ParseOptions struct
- Be more leniant when detecting rdf rss format